### PR TITLE
Update multi_column_editor_default.html.twig

### DIFF
--- a/src/Resources/views/multi_column_editor_default.html.twig
+++ b/src/Resources/views/multi_column_editor_default.html.twig
@@ -9,6 +9,9 @@
     {% endif %}
 
     {% if(rows|length < 1) %}
+        {% if isBackend %}
+            <input type="hidden" name="{{ fieldName }}" value="">
+        {% endif %}
         {% if disableAdd|default(false) %}
             <button class="add first{% if isBackend %} tl_submit{% endif %}" disabled><span>{{ 'huh.multicolumneditor.add.default'|trans }}</span></button>
         {% else %}


### PR DESCRIPTION
Fügt ein leeres verstecktes Input-Feld hinzu.
In Contao 5 können sonst die Einträge nicht mehr gelöscht werden. Es bleibt immer das letzte Feld über.