### PR TITLE
Add GetAttributesFromDcaListener

### DIFF
--- a/src/EventListener/Contao/GetAttributesFromDcaListener.php
+++ b/src/EventListener/Contao/GetAttributesFromDcaListener.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace HeimrichHannot\MultiColumnEditorBundle\EventListener\Contao;
+
+use Contao\CoreBundle\DependencyInjection\Attribute\AsHook;
+use Contao\DataContainer;
+
+#[AsHook('getAttributesFromDca')]
+class GetAttributesFromDcaListener
+{
+    public function __invoke(array $attributes, $context = null): array
+    {
+        if (str_contains($attributes['id'], '[') && $context instanceof DataContainer) {
+            $field = substr($context->field, 0, strpos($context->field, '['));
+
+            // Make sure it is actually an MCE field to not interfere with other extensions
+            if (isset($GLOBALS['TL_DCA'][$context->table]['fields'][$field]['inputType'])
+                && $GLOBALS['TL_DCA'][$context->table]['fields'][$field]['inputType'] === 'multiColumnEditor') {
+                $attributes['id'] = str_replace(['][', '[', ']'], ['_', '_', ''], $attributes['id']);
+            }
+        }
+
+        return $attributes;
+    }
+}


### PR DESCRIPTION
Updates array notation to underscores in the widget id, example: `mce[0][name]` => `mce_0_name`

Fixes https://github.com/heimrichhannot/contao-multi-column-editor-bundle/issues/38